### PR TITLE
Implement default ctor. Add non-char support for formatter specialisation

### DIFF
--- a/examples/example.cpp
+++ b/examples/example.cpp
@@ -25,6 +25,7 @@ int main() {
     std::string s = "hello world";
     std::zstring_view z0 = "hello";
     std::zstring_view z1 = s;
+    std::zstring_view empty;
     std::println("{}", z0);
     std::println("{}", s.starts_with(z0));
     std::println("{}", z0.starts_with(s));
@@ -34,9 +35,36 @@ int main() {
     std::cout<<z1<<std::endl;
     std::println("{}", "hello"zsv == "hello"sv);
     std::println("{}", "hello"zsv == "hello"zsv);
+    std::println("{}", "hello"zsv != "goodbye"sv);
+    std::println("{}", "hello"zsv != "goodbye"zsv);
     std::println("{}", z0 == z1);
     std::println("{}", to_string(z0 <=> z1));
     std::println("{}", z0[z0.size()] * 1);
     std::println("{}", z0.c_str());
+    std::println("\"{}\"", empty);
+    std::println("{}", empty == ""zsv);
     std::formatter<std::string_view> f;
+    
+    std::wstring ws = L"hello world";
+    std::wzstring_view wz0 = L"hello";
+    std::wzstring_view wz1 = ws;
+    std::wzstring_view wempty;
+    std::wcout << std::format(L"{}\n", wz0);
+    std::println("{}", ws.starts_with(wz0));
+    std::println("{}", wz0.starts_with(ws));
+    std::println("{}", wz0.starts_with(L"hello"));
+    std::println("{}", wz0.starts_with(L"hello"zsv));
+    std::println("{}", std::hash<std::wzstring_view>{}(wz1));
+    std::wcout<<wz1<<std::endl;
+    std::println("{}", L"hello"zsv == L"hello"sv);
+    std::println("{}", L"hello"zsv == L"hello"zsv);
+    std::println("{}", L"hello"zsv != L"goodbye"sv);
+    std::println("{}", L"hello"zsv != L"goodbye"zsv);
+    std::println("{}", wz0 == wz1);
+    std::println("{}", to_string(wz0 <=> wz1));
+    std::println("{}", wz0[wz0.size()] * 1);
+    std::wcout << std::format(L"{}\n", wz0.c_str());
+    std::wcout << std::format(L"\"{}\"\n", wempty);
+    std::println("{}", wempty == L""zsv);
+    std::formatter<std::wstring_view, wchar_t> wf;
 }

--- a/include/zstring_view.hpp
+++ b/include/zstring_view.hpp
@@ -14,10 +14,12 @@ namespace std {
     template<class charT, class traits = char_traits<charT>>
     class basic_zstring_view;                                              // partially freestanding
 
-    template<class charT, class traits>
-        constexpr bool ranges::enable_view<basic_zstring_view<charT, traits>> = true;
-    template<class charT, class traits>
-        constexpr bool ranges::enable_borrowed_range<basic_zstring_view<charT, traits>> = true;
+    namespace ranges {
+        template<class charT, class traits>
+            constexpr bool enable_view<basic_zstring_view<charT, traits>> = true;
+        template<class charT, class traits>
+            constexpr bool enable_borrowed_range<basic_zstring_view<charT, traits>> = true;
+    }
 
     // [zstring.view.comparison], non-member comparison functions
     template<class charT, class traits>
@@ -90,7 +92,7 @@ namespace std {
         using const_pointer          = const value_type*;
         using reference              = value_type&;
         using const_reference        = const value_type&;
-        using const_iterator         = const char*; // see [zstring.view.iterators]
+        using const_iterator         = const charT*; // see [zstring.view.iterators]
         using iterator               = const_iterator;
         using const_reverse_iterator = std::reverse_iterator<const_iterator>;
         using reverse_iterator       = const_reverse_iterator;
@@ -99,7 +101,10 @@ namespace std {
         static constexpr size_type npos = size_type(-1);
 
         // [zstring.view.cons], construction and assignment
-        constexpr basic_zstring_view() noexcept;
+        constexpr basic_zstring_view() noexcept : size_() {
+            static const charT empty_string[1]{};
+            data_ = std::data(empty_string);
+        }
         constexpr basic_zstring_view(const basic_zstring_view&) noexcept = default;
         constexpr basic_zstring_view& operator=(const basic_zstring_view&) noexcept = default;
         constexpr basic_zstring_view(const charT* str) : basic_zstring_view(str, traits::length(str)) {}
@@ -340,7 +345,7 @@ namespace std {
         basic_zstring_view<charT, traits> x,
         type_identity_t<basic_zstring_view<charT, traits>> y
     ) noexcept {
-        return basic_string_view<charT, traits>(x) == basic_string_view<charT, traits>(x);
+        return basic_string_view<charT, traits>(x) == basic_string_view<charT, traits>(y);
     }
 
     template<class charT, class traits>
@@ -348,7 +353,7 @@ namespace std {
         basic_zstring_view<charT, traits> x,
         type_identity_t<basic_zstring_view<charT, traits>> y
     ) noexcept {
-        return basic_string_view<charT, traits>(x) <=> basic_string_view<charT, traits>(x);
+        return basic_string_view<charT, traits>(x) <=> basic_string_view<charT, traits>(y);
     }
 
     template<class charT, class traits>
@@ -410,7 +415,7 @@ namespace std {
     template<class charT, class traits>
     struct formatter<basic_zstring_view<charT, traits>, charT> {
         formatter() = default;
-        constexpr auto parse(basic_format_parse_context<char>& context) {
+        constexpr auto parse(basic_format_parse_context<charT>& context) {
             return sv_formatter.parse(context);
         }
         template<typename _Out>
@@ -418,7 +423,7 @@ namespace std {
             return sv_formatter.format(zsv, context);
         }
     private:
-        formatter<basic_string_view<charT, traits>> sv_formatter;
+        formatter<basic_string_view<charT, traits>, charT> sv_formatter;
     };
 }
 


### PR DESCRIPTION
Found some other minor fixes along the way. Dup'd the tests in example.cpp for for `wzstring_view`

Originally had the idea of using a string literal for the default ctor, but realised there's no syntax for "string literal of char type `charT`", so this local static const will have to do